### PR TITLE
feat: add makefile for container rebuilds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+REGISTRY ?= docker.io/brimdor
+REPO ?= vscode-tunnel
+TAG := $(shell git describe --tags --always --dirty)
+IMG := $(REGISTRY)/$(REPO):$(TAG)
+
+ifeq ($(wildcard Containerfile),)
+  Dockerfile := Dockerfile
+else
+  Dockerfile := Containerfile
+endif
+
+all: build push
+.PHONY: all build push
+
+build:
+        docker build -t $(IMG) . -f $(Dockerfile)
+
+push:
+        docker push $(IMG)


### PR DESCRIPTION
Per the title, this adds a makefile to allow for simple image rebuilds and pushes to the registry. Swap out the registry URL for your own and run `make` to build and push the image.

Test shown below:

```bash
❯ make
docker build -t registry.lajas.tech/vscode-tunnel:fbd0e61 . -f Dockerfile
DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            Install the buildx component to build images with BuildKit:
            https://docs.docker.com/go/buildx/

Sending build context to Docker daemon  84.99kB
Step 1/7 : FROM debian:bullseye-slim
 ---> 06b60f9b8ab4
Step 2/7 : RUN apt-get update && apt-get install -y     curl     ca-certificates     git     sudo     zsh   && rm -rf /var/lib/apt/lists/*
 ---> Running in d07a6e5eed38
...
```
